### PR TITLE
Goose changed the method name

### DIFF
--- a/content/base/extractor/goose.go
+++ b/content/base/extractor/goose.go
@@ -40,7 +40,7 @@ func (e Goose) Extract(link string) (data data.ArticleExtract, err error) {
 
 	g := goose.New()
 	/* TODO: preserve links */
-	formatted := g.ExtractFromUrl(link)
+	formatted, err := g.ExtractFromURL(link)
 
 	content := formatted.CleanedText
 	buf := util.BufferPool.GetBuffer()


### PR DESCRIPTION
Goose changed the method name, causing this project to fail-to-build-from-source. https://github.com/advancedlogic/GoOse/blob/9df1c62bade124335ec97d0d845391ee54631b6f/goose.go#L16